### PR TITLE
Fix fallback message formatting

### DIFF
--- a/src/worker.mjs
+++ b/src/worker.mjs
@@ -318,7 +318,7 @@ const transformMessages = async (messages) => {
     }
   }
   if (system_instruction && contents.length === 0) {
-    contents.push({ role: "model", parts: { text: " " } });
+    contents.push({ role: "model", parts: [{ text: " " }] });
   }
   //console.info(JSON.stringify(contents, 2));
   return { system_instruction, contents };


### PR DESCRIPTION
## Summary
- fix fallback message format for empty content list

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687bb6dd3fd483308c5f6d8712ad1e41