### PR TITLE
Add PowerShell script to redact sensitive fields

### DIFF
--- a/readme.MD
+++ b/readme.MD
@@ -175,3 +175,17 @@ Implemented via [`inlineData`](https://ai.google.dev/api/caching#Part).
 - [ ] `completions`
 - [x] `embeddings`
 - [x] `models`
+
+### Remove sensitive data from text files
+
+A utility script `scripts/Remove-SensitiveData.ps1` is available to redact
+common fields such as `username`, `password`, `server` and `pcname` in a
+configuration file.
+
+Usage:
+
+```powershell
+./scripts/Remove-SensitiveData.ps1 -InputPath <file> [-OutputPath <sanitized-file>]
+```
+
+If `-OutputPath` is omitted, the original file is overwritten.

--- a/scripts/Remove-SensitiveData.ps1
+++ b/scripts/Remove-SensitiveData.ps1
@@ -1,0 +1,31 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$InputPath,
+    [string]$OutputPath
+)
+
+if (-not (Test-Path $InputPath)) {
+    Write-Error "Input file not found: $InputPath"
+    exit 1
+}
+
+$content = Get-Content $InputPath -Raw
+
+$patterns = @(
+    '(?im)^(.*\buser(name)?\b\s*[=:]\s*)(.+)$',
+    '(?im)^(.*\bpass(word)?\b\s*[=:]\s*)(.+)$',
+    '(?im)^(.*\bserver(name)?\b\s*[=:]\s*)(.+)$',
+    '(?im)^(.*\bpc(name)?\b\s*[=:]\s*)(.+)$'
+)
+
+foreach ($pattern in $patterns) {
+    $content = [Regex]::Replace($content, $pattern, '$1[REDACTED]')
+}
+
+if ($OutputPath) {
+    Set-Content -Path $OutputPath -Value $content
+    Write-Host "Sanitized file written to $OutputPath"
+} else {
+    Set-Content -Path $InputPath -Value $content
+    Write-Host "Sensitive data removed from $InputPath"
+}


### PR DESCRIPTION
## Summary
- add `Remove-SensitiveData.ps1` to sanitize text files
- document script usage in the README

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_687c9fdd7f088330b97036e3d40658d8